### PR TITLE
docs(idea): promote IDEA-011 to FEAT-012 (2D agent preview)

### DIFF
--- a/.specs/features/FEAT-012-2d-agent-preview.md
+++ b/.specs/features/FEAT-012-2d-agent-preview.md
@@ -1,0 +1,67 @@
+---
+title: "2D Rendered Preview for AI Agent Validation"
+status: Draft
+created: 2026-04-02
+epic: enhancements
+promoted_from: IDEA-011
+depends_on: [FEAT-003, FEAT-004]
+---
+
+# FEAT-012: 2D Rendered Preview for AI Agent Validation
+
+> Promoted from IDEA-011
+
+## Summary
+
+Generate a top-down 2D PNG showing all contour layers as filled, color-coded
+polygons. Unlike the SVG (stroke-only) and 3D render (perspective), this
+flat raster image is directly readable by multimodal AI models, enabling
+automated visual validation of pipeline output.
+
+## Requirements
+
+### Functional
+
+**2D Render Output**
+- Accept `--render-2d` CLI flag
+- Render each layer as filled polygons from a top-down view
+- Use distinct color gradient: blues for water, greens/browns for land
+- Layer boundaries visible through color stepping (not just outlines)
+- Output as PNG alongside SVG (e.g., `output/render_2d.png`)
+
+**Legend**
+- Include a color legend showing layer numbers and elevation ranges
+- Legend positioned outside the map area (right side or bottom)
+
+**Resolution**
+- Default ~1200px wide, aspect ratio matching the map
+- Sufficient detail for AI model inspection of contour shapes
+
+### Non-Functional
+- Generation should complete in under 5 seconds
+- No additional dependencies beyond matplotlib (already in core deps)
+- Output must be a standard PNG readable by the Read tool
+
+## Technical Approach
+
+1. Reuse `_layer_color()` and `_collect_polygons()` from `render/renderer.py`
+2. Use matplotlib 2D figure with `fill()` or `PatchCollection` for polygons
+3. Render layers bottom-to-top so higher layers overlap lower ones
+4. Add colorbar or discrete legend mapping colors to elevation ranges
+5. Save with `savefig()` at specified DPI
+
+## Files to Create/Modify
+
+- `topo2laser/render/renderer.py` — Add `render_2d()` function
+- `topo2laser/cli.py` — Add `--render-2d` flag
+- `topo2laser/pipeline.py` — Wire 2D render stage
+- `tests/test_render.py` — Add tests for 2D render
+
+## Acceptance Criteria
+
+- [ ] `--render-2d` generates a top-down PNG with filled color layers
+- [ ] Water layers use blue gradient, land layers use green/brown gradient
+- [ ] Layer boundaries are visually distinguishable
+- [ ] Output resolution sufficient for AI inspection (~1200px wide)
+- [ ] Legend shows layer elevation ranges
+- [ ] Claude Code can read the PNG via Read tool and describe what it sees

--- a/.specs/ideas/IDEA-011-2d-agent-preview.md
+++ b/.specs/ideas/IDEA-011-2d-agent-preview.md
@@ -1,8 +1,14 @@
 ---
 title: "2D Rendered Preview for AI Agent Validation"
-status: Captured
+status: Promoted
 created: 2026-04-01
 source: user
+promoted_to: FEAT-012
+ice_scores:
+  impact: 9
+  confidence: 9
+  ease: 8
+  total: 648
 ---
 
 # IDEA-011: 2D Rendered Preview for AI Agent Validation
@@ -37,3 +43,11 @@ a raster image that AI agents can read.
 - Enables AI-assisted development loop: change code → generate → inspect → fix
 - Reduces reliance on human visual review for every pipeline change
 - Could be integrated into CI or test workflows for regression detection
+
+## Prioritization Notes (2026-04-02)
+
+ICE 648 (I:9 C:9 E:8). Promoted to FEAT-012. High impact because it
+unlocks AI-driven development feedback loops — Claude Code can read the
+PNG and validate output visually. High confidence because matplotlib 2D
+rendering is straightforward. High ease because we already have the
+layer data and coloring logic from the 3D renderer.

--- a/.specs/ideas/IDEA-011-2d-agent-preview.md
+++ b/.specs/ideas/IDEA-011-2d-agent-preview.md
@@ -1,0 +1,39 @@
+---
+title: "2D Rendered Preview for AI Agent Validation"
+status: Captured
+created: 2026-04-01
+source: user
+---
+
+# IDEA-011: 2D Rendered Preview for AI Agent Validation
+
+## Problem
+
+The 3D matplotlib preview (`--render`) is useful for human inspection but
+cannot be consumed by AI agents like Claude Code. When making changes to
+contour generation, SVG output, or layer logic, there's no way for an AI
+agent to visually verify the output looks correct — it can only check that
+files were created, not that they look right.
+
+A flat 2D rendered PNG with color-coded layers would be readable by
+multimodal AI models, enabling a feedback loop where the agent can generate
+a map, look at the preview, and identify issues (missing layers, broken
+polygons, incorrect coastlines, etc.) without human intervention.
+
+## Proposed Solution
+
+Add a `--render-2d` flag that generates a top-down 2D PNG showing all
+contour layers with distinct colors, similar to how the SVG looks but as
+a raster image that AI agents can read.
+
+- Render each layer as filled polygons (not just strokes)
+- Use a clear color gradient: blues for water, greens/browns for land
+- Include layer boundaries visible through slight color differences
+- Output at sufficient resolution for AI model inspection (~1200px wide)
+- Optionally include a legend showing layer elevation ranges
+
+## Value Signal
+
+- Enables AI-assisted development loop: change code → generate → inspect → fix
+- Reduces reliance on human visual review for every pipeline change
+- Could be integrated into CI or test workflows for regression detection


### PR DESCRIPTION
## Summary

- Score IDEA-011 (2D agent preview) with ICE 648 and promote to FEAT-012
- Create GitHub issue #12 and feature spec
- Enables AI-driven visual validation of pipeline output

## Test plan

- [x] Docs/metadata only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)