### PR TITLE
docs(idea): promote IDEA-012 to FEAT-013 (visual dev loop)

### DIFF
--- a/.specs/features/FEAT-013-visual-dev-loop.md
+++ b/.specs/features/FEAT-013-visual-dev-loop.md
@@ -1,0 +1,92 @@
+---
+title: "Visual Development Feedback Loop with Reference Map Comparison"
+status: Draft
+created: 2026-04-02
+epic: developer-experience
+promoted_from: IDEA-012
+depends_on: [FEAT-012]
+---
+
+# FEAT-013: Visual Development Feedback Loop with Reference Map Comparison
+
+> Promoted from IDEA-012
+
+## Summary
+
+Create a development workflow where Claude Code visually validates pipeline
+output by generating a 2D contour preview (FEAT-012) and comparing it against
+a reference map image (satellite or topographic) for the same bounding box.
+This enables autonomous detect-and-fix cycles: the agent makes a change, runs
+the pipeline, reads both images, checks that coastlines/terrain/layers
+correlate with reality, and iterates if something looks wrong.
+
+## Requirements
+
+### Functional
+
+**Reference Map Fetcher**
+- Fetch a static map image for a given bounding box
+- Support multiple sources: OSM tiles, OpenTopoMap, USGS topo
+- Output as PNG at comparable resolution to the 2D contour preview
+- Cache fetched images by bbox hash to avoid repeated network calls
+
+**Visual Comparison Workflow**
+- Generate contour 2D preview via `--render-2d` (FEAT-012)
+- Fetch or load cached reference map for the same bbox
+- Present both images for AI agent inspection (Read tool)
+- Agent checks for:
+  - Coastline alignment (do island shapes match?)
+  - Terrain correlation (do elevation bands match visible features?)
+  - Missing features (islands, peninsulas, lakes present in reference?)
+  - Obvious artifacts (broken polygons, projection warping)
+
+**Integration Points**
+- `/validate-visual` slash command for on-demand validation
+- Optional integration into `/feature complete` for pipeline features
+- Reference test locations: Kaua'i (coast/islands), Duluth (lake/urban)
+
+**Reference Image CLI**
+- `--fetch-reference` flag to save a reference map image alongside output
+- Stored as `output/reference_map.png`
+
+### Non-Functional
+- Reference fetch should complete in under 10 seconds
+- Cached images stored in the same cache directory as elevation data
+- No API keys required (use free tile sources)
+- Respect tile server usage policies (user-agent, rate limiting)
+
+## Technical Approach
+
+1. Create `topo2laser/reference/fetcher.py` — fetch OSM/topo map tiles
+   for a bbox, stitch into a single image at target resolution
+2. Use `contextily` library (already used in geo Python workflows) or
+   direct tile URL fetching with `requests` + `PIL`
+3. Add `/validate-visual` skill that orchestrates: run pipeline →
+   generate 2D preview → fetch reference → read both → report
+4. Cache reference images keyed on bbox hash + source
+
+## Files to Create/Modify
+
+- `topo2laser/reference/__init__.py` — Module init
+- `topo2laser/reference/fetcher.py` — Map tile fetching and stitching
+- `topo2laser/cli.py` — Add `--fetch-reference` flag
+- `topo2laser/pipeline.py` — Wire reference fetch stage
+- `.claude/skills/validate-visual/SKILL.md` — Slash command for validation
+- `tests/test_reference.py` — Unit tests
+
+## Open Questions
+
+- Best tile source for correlation? OpenTopoMap shows contours which could
+  be confusing. Plain OSM or satellite may be better for coastline comparison.
+- Should the agent compare images programmatically (pixel diff, SSIM) in
+  addition to visual inspection, or is AI vision sufficient?
+- How to handle bbox areas with no reference tiles (remote ocean areas)?
+
+## Acceptance Criteria
+
+- [ ] Reference map image fetched and cached for a given bbox
+- [ ] `--fetch-reference` saves reference map alongside output
+- [ ] `/validate-visual` runs pipeline, fetches reference, reads both images
+- [ ] Claude Code can identify coastline mismatches between contour and reference
+- [ ] Reference images cached — second fetch for same bbox uses cache
+- [ ] Works for both Kaua'i (ocean/islands) and Duluth (lake/urban) test areas

--- a/.specs/ideas/IDEA-012-visual-dev-loop.md
+++ b/.specs/ideas/IDEA-012-visual-dev-loop.md
@@ -1,8 +1,14 @@
 ---
 title: "Visual Development Feedback Loop via 2D Previews"
-status: Captured
+status: Promoted
 created: 2026-04-02
 source: user
+promoted_to: FEAT-013
+ice_scores:
+  impact: 10
+  confidence: 7
+  ease: 7
+  total: 490
 ---
 
 # IDEA-012: Visual Development Feedback Loop via 2D Previews
@@ -26,19 +32,28 @@ feature development. After making changes, Claude Code would:
 
 1. Run the pipeline on a reference bounding box (e.g., Kaua'i)
 2. Generate the 2D preview PNG
-3. Read the PNG with the multimodal Read tool
-4. Analyze the image for common issues:
+3. Fetch a reference map image (satellite or topo map) for the same bbox
+4. Read both PNGs with the multimodal Read tool
+5. Compare: do coastlines align? Are islands present? Do elevation bands
+   correlate with terrain features visible in the reference?
+6. Analyze the contour image for common issues:
    - Missing or empty layers
    - Broken/invalid polygon shapes
    - Coastline artifacts from projection
    - Layer ordering issues (water above land)
    - Missing frame or alignment marks
-5. Report findings or iterate on fixes
+7. Report findings or iterate on fixes
+
+**Reference map sources:**
+- OpenStreetMap static tiles via URL (free, no API key)
+- USGS topo map tiles
+- OpenTopoMap (topo contours overlaid on OSM)
+- Cache reference images per bbox to avoid repeated fetches
 
 **Potential implementations:**
 - A `/validate-visual` slash command that runs the pipeline and inspects output
+- A reference image fetcher that grabs a map tile for the same bbox
 - A post-commit hook that generates a preview on pipeline code changes
-- A reference image comparison (generate → diff against known-good baseline)
 - Integration into `/feature complete` to auto-validate before PR creation
 
 ## Value Signal
@@ -59,3 +74,12 @@ feature development. After making changes, Claude Code would:
 ## Dependencies
 
 - Requires FEAT-012 (2D rendered preview) to be implemented first
+
+## Prioritization Notes (2026-04-02)
+
+ICE 490 (I:10 C:7 E:7). Promoted to FEAT-013. Impact is maximum because
+this fundamentally changes how autonomously Claude Code can develop pipeline
+features — from blind code changes to visually-validated iterations.
+Confidence slightly lower because AI visual comparison reliability is
+unproven. Ease moderate because it requires the reference map fetcher plus
+workflow integration.

--- a/.specs/ideas/IDEA-012-visual-dev-loop.md
+++ b/.specs/ideas/IDEA-012-visual-dev-loop.md
@@ -1,0 +1,61 @@
+---
+title: "Visual Development Feedback Loop via 2D Previews"
+status: Captured
+created: 2026-04-02
+source: user
+---
+
+# IDEA-012: Visual Development Feedback Loop via 2D Previews
+
+## Problem
+
+When Claude Code makes changes to contour generation, SVG output, projection,
+or rendering logic, the only validation available is unit tests and file
+existence checks. There's no automated way to verify that the *visual output*
+is correct — that coastlines look right, layers are properly stacked, polygons
+aren't broken, etc.
+
+This means every pipeline change requires the user to manually inspect the
+output, creating a bottleneck in the development loop.
+
+## Proposed Solution
+
+Create a development workflow (and optionally a slash command or hook) that
+uses FEAT-012's `--render-2d` output as a visual validation step during
+feature development. After making changes, Claude Code would:
+
+1. Run the pipeline on a reference bounding box (e.g., Kaua'i)
+2. Generate the 2D preview PNG
+3. Read the PNG with the multimodal Read tool
+4. Analyze the image for common issues:
+   - Missing or empty layers
+   - Broken/invalid polygon shapes
+   - Coastline artifacts from projection
+   - Layer ordering issues (water above land)
+   - Missing frame or alignment marks
+5. Report findings or iterate on fixes
+
+**Potential implementations:**
+- A `/validate-visual` slash command that runs the pipeline and inspects output
+- A post-commit hook that generates a preview on pipeline code changes
+- A reference image comparison (generate → diff against known-good baseline)
+- Integration into `/feature complete` to auto-validate before PR creation
+
+## Value Signal
+
+- Dramatically reduces human review burden for pipeline changes
+- Catches visual regressions that unit tests miss
+- Enables more autonomous feature development on the pipeline
+- Reference image baselines could serve as visual regression tests
+
+## Open Questions
+
+- What reference locations should be used? (Kaua'i is good for coast/ocean,
+  Duluth for lake/land, maybe a mountainous area for high layer counts)
+- Should we store reference "known good" PNGs for comparison?
+- How reliable is AI visual inspection for subtle issues like projection
+  artifacts or slightly wrong coastlines?
+
+## Dependencies
+
+- Requires FEAT-012 (2D rendered preview) to be implemented first


### PR DESCRIPTION
## Summary

- Augment IDEA-012 with reference map comparison — fetch satellite/topo imagery for the same bbox to correlate against generated contour layers
- Promote to FEAT-013 with ICE score 490
- Create GitHub issue #15 and feature spec

## What This Enables

Claude Code can autonomously validate pipeline output:
1. Make a code change
2. Run pipeline → generate 2D contour preview
3. Fetch reference map (OSM/topo tiles) for same bbox
4. Read both images, compare coastlines and terrain
5. Fix issues and iterate — no human review needed

## Dependencies

- FEAT-012 (2D rendered preview) must be built first
- Reference map fetching via OSM tiles (no API key needed)

## Test plan

- [x] Docs/metadata only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)