### PR TITLE
fix: restore 3D render Z-aspect fix and --render flag

### DIFF
--- a/scripts/generate-reference.sh
+++ b/scripts/generate-reference.sh
@@ -41,6 +41,7 @@ generate_location() {
         --layers "$layers"
         --width "$width"
         --render-2d
+        --render
     )
 
     local water_level land_layers_cfg
@@ -68,6 +69,7 @@ generate_location() {
 
     # Copy renders to reference directory
     cp "$REF_DIR/$location/output/render_2d.png" "$REF_DIR/$location/render_2d.png"
+    cp "$REF_DIR/$location/output/render.png" "$REF_DIR/$location/render_3d.png" 2>/dev/null || true
 
     # Copy per-layer SVGs
     mkdir -p "$REF_DIR/$location/layers"

--- a/topo2laser/render/renderer.py
+++ b/topo2laser/render/renderer.py
@@ -357,8 +357,9 @@ def render_3d(
     # Set camera angle for a nice isometric-ish view
     ax.view_init(elev=35, azim=-60)
 
-    # Equal aspect ratio for X and Y
-    ax.set_box_aspect([width_mm, height_mm, total_z * 3])
+    # Set aspect ratio — ensure Z is visible relative to X/Y
+    z_aspect = max(total_z * 3, max(width_mm, height_mm) * 0.15)
+    ax.set_box_aspect([width_mm, height_mm, z_aspect])
 
     plt.tight_layout()
 


### PR DESCRIPTION
## Summary

- Fix 3D render crash on small Z ranges (singular matrix from tiny Z aspect)
- Re-enable `--render` flag in generate-reference.sh so 3D renders are regenerated
- Add missing `render_3d.png` copy step

These were in PR #25's later commits but lost during merge.

## Test plan

- [x] 42 tests pass
- [x] `./scripts/generate-reference.sh` produces 3D renders without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)